### PR TITLE
Improve speed with Docker rules

### DIFF
--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -112,7 +112,12 @@ def get_from_target(ctx, name, attr_target, file_target = None):
        The extracted layers
     """
     if file_target:
-        return _extract_layers(ctx, name, file_target)
+        if ImageInfo in file_target:
+             return file_target[ImageInfo].container_parts
+        elif ImportInfo in file_target:
+             return file_target[ImportInfo].container_parts
+        else:
+            return _extract_layers(ctx, name, file_target)
     elif attr_target and ImageInfo in attr_target:
         return attr_target[ImageInfo].container_parts
     elif attr_target and ImportInfo in attr_target:


### PR DESCRIPTION
We improve two cases:

- Our code in https://github.com/TEA-ebook/TEA-ebook create container from template files. We use the `image.implementation` function that is not very fast in this specific use (ie. it needs to recreate the full tar of the image instead of working with layers). The first commit improves this.
- When pushing to Docker to avoid recreating the full image the code try to find what part of the image is missing. This improve speed when only the last layers are modified. However, with an image with many layers, Docker is called many time. We changed the order in which the layers are processed to start by the last one first.